### PR TITLE
fixed list in article about quality badge

### DIFF
--- a/docs/configuration/config_code_quality_badge.rst
+++ b/docs/configuration/config_code_quality_badge.rst
@@ -7,9 +7,7 @@ Badges
 You can show the code quality of your projects by adding a code quality badge to the README of your project.
 
 Here's how:
+
 - Go to “Your projects” and click on the settings symbol
 - In the sidebar, click on "Badge” and copy either the HTML, MarkDown, Textile or RDOC code
 - Add the code to your README, website, etc.
-
-
-


### PR DESCRIPTION
The article about quality badges was missing an empty line. This resulted in bad rendering of the list (see http://docs.quantifiedcode.com/configuration/config_code_quality_badge.html).

I also removed trailing newlines at the end of the file.